### PR TITLE
Fixed link for sequence modem

### DIFF
--- a/tutorials/lte/firmware.md
+++ b/tutorials/lte/firmware.md
@@ -29,7 +29,7 @@ Please start with the following steps:
 1. Upgrade the Pycom Firmware Updater tool to latest version
 2. Select Firmware Type `stable` in the communication window to upgrade to version `v1.18.1.r1`
 
-You can find the different versions of firmwares available here: [ http://software.pycom.io/downloads/sequans2.html​](http://software.pycom.io/downloads/sequans2.html​)
+You can find the different versions of firmwares available [here](https://software.pycom.io/downloads/sequans2.html).
 
 These files are password protected, to download them you should be a forum.pycom.io member and access to: 
 Announcements & News --&gt;  Announcements only for members --&gt; Firmware Files for Sequans LTE modem now are secured, or clicking [Here](https://forum.pycom.io/topic/4020/firmware-files-for-sequans-lte-modem-now-are-secured).


### PR DESCRIPTION
the previous link used http://.. URL which when opened in browser malformed it to:

https://software.pycom.io/downloads/sequans2.html%E2%80%8B

and the page did not load